### PR TITLE
Load gangs from database on startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,110 @@
-# territorios
-prueba de territorios
+# Sistema de Gangs con Carga desde Base de Datos
+
+Este recurso carga dinámicamente las gangs desde la base de datos en lugar de usar valores hardcodeados.
+
+## Características
+
+- ✅ Carga automática de gangs desde la tabla `origen_ilegal` al iniciar el servidor
+- ✅ Color rojo por defecto para todas las gangs (configurable)
+- ✅ Sistema de eventos para sincronizar entre servidor y cliente
+- ✅ Funciones exportadas para uso en otros recursos
+- ✅ Comando de consola para recargar gangs
+
+## Estructura de la Base de Datos
+
+El sistema consulta la tabla `origen_ilegal` y obtiene el campo `id` para crear las gangs:
+
+```sql
+SELECT id FROM origen_ilegal WHERE id IS NOT NULL AND id != ''
+```
+
+## Configuración
+
+### Color por Defecto
+En `shared.lua` puedes cambiar el color por defecto:
+```lua
+Config.DefaultBlipColor = 1 -- Color rojo (1-85 según documentación FiveM)
+```
+
+### Colores de Blip Disponibles
+- 1: Rojo
+- 2: Verde
+- 3: Azul
+- 4: Amarillo
+- 5: Naranja
+- 6: Púrpura
+- 7: Rosa
+- 8: Blanco
+- Y muchos más (consulta la documentación de FiveM)
+
+## Uso en Otros Recursos
+
+### Desde el Servidor
+```lua
+-- Obtener todas las gangs
+local gangs = exports['tu-recurso']:GetGangs()
+
+-- Verificar si una gang existe
+local exists = exports['tu-recurso']:GangExists('gsf')
+
+-- Obtener color de blip
+local color = exports['tu-recurso']:GetGangBlipColor('gsf')
+
+-- Verificar si las gangs están cargadas
+local loaded = exports['tu-recurso']:AreGangsLoaded()
+```
+
+### Desde el Cliente
+```lua
+-- Obtener todas las gangs
+local gangs = exports['tu-recurso']:GetGangs()
+
+-- Verificar si una gang existe
+local exists = exports['tu-recurso']:GangExists('gsf')
+
+-- Obtener color de blip
+local color = exports['tu-recurso']:GetGangBlipColor('gsf')
+
+-- Verificar si las gangs están cargadas
+local loaded = exports['tu-recurso']:AreGangsLoaded()
+```
+
+## Eventos
+
+### Servidor → Cliente
+- `gangs:loaded`: Se dispara cuando las gangs han sido cargadas
+
+### Cliente → Servidor
+- `gangs:requestGangs`: Solicita las gangs al servidor
+
+## Comandos de Consola
+
+- `reloadgangs`: Recarga las gangs desde la base de datos
+
+## Dependencias
+
+- `mysql-async`: Para consultas a la base de datos
+
+## Instalación
+
+1. Coloca el recurso en tu carpeta `resources`
+2. Asegúrate de tener `mysql-async` instalado
+3. Agrega `ensure tu-recurso` a tu `server.cfg`
+4. Reinicia el servidor
+
+## Logs
+
+El sistema genera logs informativos:
+- `[CARGANDO GANGS]`: Logs del servidor
+- `[CLIENTE GANGS]`: Logs del cliente
+
+## Estructura de Archivos
+
+```
+tu-recurso/
+├── fxmanifest.lua
+├── shared.lua
+├── server.lua
+├── client.lua
+└── README.md
+```

--- a/client.lua
+++ b/client.lua
@@ -1,0 +1,50 @@
+-- Cliente - Manejo de gangs cargadas desde el servidor
+local gangsLoaded = false
+local gangsData = {}
+
+-- Evento para recibir las gangs cargadas desde el servidor
+RegisterNetEvent('gangs:loaded')
+AddEventHandler('gangs:loaded', function(gangs)
+    gangsData = gangs
+    gangsLoaded = true
+    
+    print("^2[CLIENTE GANGS]^7 Gangs recibidas del servidor:")
+    for gangId, gangData in pairs(gangs) do
+        print("^3[CLIENTE GANGS]^7 Gang: " .. gangId .. " - Color: " .. gangData.blipColour)
+    end
+end)
+
+-- Función para obtener las gangs (para uso en otros scripts)
+function GetGangs()
+    return gangsData
+end
+
+-- Función para verificar si una gang existe
+function GangExists(gangId)
+    return gangsData[gangId] ~= nil
+end
+
+-- Función para obtener el color de blip de una gang
+function GetGangBlipColor(gangId)
+    if gangsData[gangId] then
+        return gangsData[gangId].blipColour
+    end
+    return 1 -- Color rojo por defecto
+end
+
+-- Función para verificar si las gangs están cargadas
+function AreGangsLoaded()
+    return gangsLoaded
+end
+
+-- Solicitar gangs al servidor cuando el cliente esté listo
+Citizen.CreateThread(function()
+    Citizen.Wait(2000) -- Esperar un poco para que el servidor esté listo
+    TriggerServerEvent('gangs:requestGangs')
+end)
+
+-- Exportar funciones para uso en otros recursos
+exports('GetGangs', GetGangs)
+exports('GangExists', GangExists)
+exports('GetGangBlipColor', GetGangBlipColor)
+exports('AreGangsLoaded', AreGangsLoaded)

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -1,0 +1,22 @@
+fx_version 'cerulean'
+game 'gta5'
+
+author 'Tu Nombre'
+description 'Sistema de Gangs con carga desde base de datos'
+version '1.0.0'
+
+shared_scripts {
+    'shared.lua'
+}
+
+server_scripts {
+    'server.lua'
+}
+
+client_scripts {
+    'client.lua'
+}
+
+dependencies {
+    'mysql-async'
+}

--- a/server.lua
+++ b/server.lua
@@ -1,0 +1,88 @@
+-- Servidor principal - Carga de gangs desde base de datos
+local gangsLoaded = false
+
+-- Función para cargar gangs desde la base de datos
+function LoadGangsFromDatabase()
+    print("^2[CARGANDO GANGS]^7 Iniciando carga de gangs desde la base de datos...")
+    
+    -- Query para obtener todas las gangs de la tabla origen_ilegal
+    local query = "SELECT id FROM origen_ilegal WHERE id IS NOT NULL AND id != ''"
+    
+    MySQL.Async.fetchAll(query, {}, function(result)
+        if result and #result > 0 then
+            print("^2[CARGANDO GANGS]^7 Encontradas " .. #result .. " gangs en la base de datos")
+            
+            -- Limpiar el array de gangs existente
+            Config.Gangs = {}
+            
+            -- Agregar cada gang encontrada
+            for i = 1, #result do
+                local gangId = result[i].id
+                if gangId and gangId ~= "" then
+                    Config.AddGang(gangId, Config.DefaultBlipColor)
+                    print("^3[CARGANDO GANGS]^7 Gang cargada: " .. gangId .. " (Color: " .. Config.DefaultBlipColor .. ")")
+                end
+            end
+            
+            gangsLoaded = true
+            print("^2[CARGANDO GANGS]^7 ¡Carga de gangs completada! Total: " .. #Config.Gangs)
+            
+            -- Trigger para notificar a los clientes que las gangs han sido cargadas
+            TriggerClientEvent('gangs:loaded', -1, Config.Gangs)
+            
+        else
+            print("^1[CARGANDO GANGS]^7 No se encontraron gangs en la base de datos")
+            gangsLoaded = true
+        end
+    end)
+end
+
+-- Función para recargar gangs (útil para comandos de admin)
+function ReloadGangs()
+    LoadGangsFromDatabase()
+end
+
+-- Evento para cuando el servidor esté listo
+AddEventHandler('onResourceStart', function(resourceName)
+    if GetCurrentResourceName() == resourceName then
+        print("^2[CARGANDO GANGS]^7 Recurso iniciado, cargando gangs...")
+        LoadGangsFromDatabase()
+    end
+end)
+
+-- Comando para recargar gangs (solo para admins)
+RegisterCommand('reloadgangs', function(source, args, rawCommand)
+    if source == 0 then -- Solo desde consola del servidor
+        print("^2[CARGANDO GANGS]^7 Recargando gangs por comando...")
+        ReloadGangs()
+    end
+end, true)
+
+-- Evento para obtener gangs cuando un cliente se conecta
+RegisterNetEvent('gangs:requestGangs')
+AddEventHandler('gangs:requestGangs', function()
+    local source = source
+    if gangsLoaded then
+        TriggerClientEvent('gangs:loaded', source, Config.Gangs)
+    end
+end)
+
+-- Función para verificar si las gangs están cargadas
+function AreGangsLoaded()
+    return gangsLoaded
+end
+
+-- Exportar funciones para uso en otros recursos
+exports('GetGangs', function()
+    return Config.Gangs
+end)
+
+exports('GangExists', function(gangId)
+    return Config.GangExists(gangId)
+end)
+
+exports('GetGangBlipColor', function(gangId)
+    return Config.GetGangBlipColor(gangId)
+end)
+
+exports('AreGangsLoaded', AreGangsLoaded)

--- a/shared.lua
+++ b/shared.lua
@@ -1,0 +1,33 @@
+-- Configuración de gangs cargada dinámicamente desde la base de datos
+Config = {}
+
+-- Variable global para almacenar las gangs cargadas desde la base de datos
+Config.Gangs = {}
+
+-- Color por defecto para todas las gangs (rojo)
+Config.DefaultBlipColor = 1 -- Color rojo según la documentación de FiveM
+
+-- Función para agregar una gang al array
+function Config.AddGang(gangId, blipColor)
+    Config.Gangs[gangId] = {
+        blipColour = blipColor or Config.DefaultBlipColor
+    }
+end
+
+-- Función para obtener todas las gangs
+function Config.GetGangs()
+    return Config.Gangs
+end
+
+-- Función para verificar si una gang existe
+function Config.GangExists(gangId)
+    return Config.Gangs[gangId] ~= nil
+end
+
+-- Función para obtener el color de blip de una gang
+function Config.GetGangBlipColor(gangId)
+    if Config.Gangs[gangId] then
+        return Config.Gangs[gangId].blipColour
+    end
+    return Config.DefaultBlipColor
+end


### PR DESCRIPTION
Implement dynamic gang loading from the `origen_ilegal` database table to replace hardcoded gang definitions and allow for flexible management.

---
<a href="https://cursor.com/background-agent?bcId=bc-e9b1c366-d2ca-4e3d-9bcf-6d0ad8497276"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e9b1c366-d2ca-4e3d-9bcf-6d0ad8497276"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

